### PR TITLE
Use Kindle Previewer to create MOBI file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 
-all: svsv.mobi
-
-svsv.mobi: svsv.html svsv.opf
-	kindlegen svsv.opf
+all: svsv.html
 
 svsv.html: lexin_utf8.xml
 	python transform.py > svsv.html

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ About
 
 Creates a Swedish-Swedish dictionary for Kindle, starting with LEXIN from http://spraakbanken.gu.se/
 
-Kindle Previewer is needed for converting to MOBI (https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765261)
+[Kindle Previewer](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765261) is needed for converting to MOBI.
 
 Usage
 -----
@@ -17,7 +17,7 @@ To generate the dictionary as HTML, simply run make with no options in this dire
 
 The HTML file is referenced in `svsv.opf` so now we can create the MOBI file using Kindle Previewer.
 
-Install Kindle Previewer and open `svsv.opf`.
+Install Kindle Previewer, open it and open the `svsv.opf` file in the Previewer.
 
 Export to MOBI in the menu: `File -> Export` and select MOBI as the file format.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,21 @@ About
 
 Creates a Swedish-Swedish dictionary for Kindle, starting with LEXIN from http://spraakbanken.gu.se/
 
-Uses KindleGen (http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211)
+Kindle Previewer is needed for converting to MOBI (https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765261)
 
 Usage
 -----
 
-To generate the dictionary, simply run make with no options in this directory. 
+To generate the dictionary as HTML, simply run make with no options in this directory. 
 
     $ make
 
+The HTML file is referenced in `svsv.opf` so now we can create the MOBI file using Kindle Previewer.
+
+Install Kindle Previewer and open `svsv.opf`.
+
+Export to MOBI in the menu: `File -> Export` and select MOBI as the file format.
+
+Sideload the dictionary onto the E-reader by putting the dictionary MOBI file in the `Documents` folder of the E-reader.
+
+The dictionary should now be seen in the list of dictionaries on the E-reader: `Settings -> All Settings -> Language and Dictionaries > Dictionaries` and will be used for books in the dictionary language.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ About
 
 Creates a Swedish-Swedish dictionary for Kindle, starting with LEXIN from http://spraakbanken.gu.se/
 
-[Kindle Previewer](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765261) is needed for converting to MOBI.
+[Kindle Previewer](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765261) is needed for converting the dictionary to a MOBI file.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To generate the dictionary as HTML, simply run make with no options in this dire
 
     $ make
 
-The HTML file is referenced in `svsv.opf` so now we can create the MOBI file using Kindle Previewer.
+The created HTML file `svsv.html` is referenced in `svsv.opf` so now we can create the MOBI file using Kindle Previewer.
 
 Install Kindle Previewer, open it and open the `svsv.opf` file in the Previewer.
 

--- a/transform.py
+++ b/transform.py
@@ -18,13 +18,13 @@ for lemma in root.iter('lemma-entry'):
 
     sys.stdout.write("<idx:entry>")
     sys.stdout.write("<idx:orth>")
-    sys.stdout.write(("<b>"+form.text.replace('~','')+"</b> ").encode('utf8'))
+    sys.stdout.write(("<b>"+form.text.replace('~','')+"</b> "))
 
     if(inflection != None and inflection.text != None and len(inflection.text)!=0):
         sys.stdout.write("<idx:infl>")
         for s in inflection.text.split(' '):
             sys.stdout.write("<idx:iform value=\"")
-            sys.stdout.write(s.encode('utf8'))
+            sys.stdout.write(s)
             sys.stdout.write("\" />")
         sys.stdout.write("</idx:infl>")
 
@@ -44,7 +44,7 @@ for lemma in root.iter('lemma-entry'):
         compounds = lexeme.findall('compound')
         
         if(makelist): sys.stdout.write("<li>")
-        if(definition != None):sys.stdout.write(definition.text.encode('utf8'))
+        if(definition != None):sys.stdout.write(definition.text)
         if(makelist): sys.stdout.write("</li>")
          
     if(makelist): sys.stdout.write("</ol>")


### PR DESCRIPTION
- Removed the usage of the deprecated kindlegen tool.
- Added instructions for how to use Kindle Previewer to create dictionary as MOBI file.
- Fixed script to work with Python 3.

Kindle Previewer can be used in command-line mode for conversion. But for me it only converted the dictionary to a KPF file, not to a MOBI file.
A KPF file cannot be used as a dictionary on a Kindle as far as I know so the instructions uses the Kindle Previewer GUI to export to MOBI.